### PR TITLE
Update pop_types.txt to include Immigration to North America

### DIFF
--- a/ParadoxPlazaMod/common/pop_types.txt
+++ b/ParadoxPlazaMod/common/pop_types.txt
@@ -550,7 +550,10 @@ emigration_chance =
 
 	modifier = {
 		factor = -2.0
+		OR = {
 		continent = south_america
+		continent = north_america
+		}
 		government = democracy
 	}
 	modifier = {
@@ -707,6 +710,7 @@ assimilation_chance = {
 		is_primary_culture = no
 		OR = {
 			continent = south_america
+			continent = north_america
 			continent = oceania
 		}
 	}
@@ -714,6 +718,7 @@ assimilation_chance = {
 		factor = -20
 		has_pop_culture = afro_american
 		continent = south_america
+		continent = north_america
 	}
 	modifier = {
 		factor = -10000


### PR DESCRIPTION
Added continent = north_america where south america was an option so that the US will gain the correct assimilation and immigration bonuses. This is present in the base game and was only removed due to a change that made North America and South America 1 continent, which has been reverted. This feature was not re-added when the change was reverted.

Pointed out by /u/Maqre on the Reddit.
