### PR TITLE
Fixing Blockades Prevening Unit Movement in Japan

### DIFF
--- a/ParadoxPlazaMod/map/adjacencies.csv
+++ b/ParadoxPlazaMod/map/adjacencies.csv
@@ -93,8 +93,8 @@ From;To;Type;Through;Data;Comment
 1640;1660;land;2843;0;Fukuoka Strait
 1642;1672;sea;2841;0;Hakodate Strait
 1643;1087;sea;2831;0;Sakhalin Strait
-1664;1666;land;2843;0;Matsuyama Strait
-1667;1659;land;2843;0;Setto Strait
+1664;1666;sea;2843;0;Matsuyama Strait
+1667;1659;sea;2843;0;Setto Strait
 1411;1408;sea;2803;0;Gunungsitoli Strait
 1404;1399;land;2813;0;Palak Panang Strait
 1402;1398;sea;2814;0;Tanjungpinang Strait


### PR DESCRIPTION
For two straits in Japan connecting to the island of Shinkoku units
could move while the island was being blockaded